### PR TITLE
Adds a devtest script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "lint": "eslint --quiet .",
     "fix": "eslint --fix .",
-    "test": "npm run lint && cross-env NODE_ENV=test mocha -u bdd --reporter spec --exit"
+    "test": "npm run lint && cross-env NODE_ENV=test mocha -u bdd --reporter spec --exit",
+    "devtest": "npm run lint && cross-env NODE_ENV=development mocha -u bdd --reporter spec --exit"
   },
   "license": "ISC",
   "dependencies": {

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ var syncOptions = { force: false };
 
 // If running a test, set syncOptions.force to true
 // clearing the `testdb`
-if (process.env.NODE_ENV === "test") {
+if (process.env.NODE_ENV === "test" || process.env.NODE_ENV === "development") {
   syncOptions.force = true;
 }
 


### PR DESCRIPTION
Running tests on a development machine conflated the Travis CI test config because the test set the env to test.